### PR TITLE
Fix set environment variable cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release": "yarn build && yarn release:electron",
     "release:electron": "electron-builder -mwl -p always",
     "start": "vue-cli-service serve",
-    "start:electron": "NODE_ENV=development electron ."
+    "start:electron": "cross-env NODE_ENV=development electron ."
   },
   "main": "electron.js",
   "dependencies": {
@@ -47,6 +47,7 @@
     "@vue/cli-service": "~5.0.0-rc.1",
     "@vue/compiler-sfc": "^3.2.26",
     "@vue/eslint-config-standard": "^6.1.0",
+    "cross-env": "^7.0.3",
     "electron": "^16.0.6",
     "electron-builder": "^22.14.5",
     "eslint": "^8.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3665,6 +3665,13 @@ crc@^3.8.0:
   dependencies:
     buffer "^5.1.0"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"


### PR DESCRIPTION
Fix `electron-start` script for Windows

Resolves #35