### PR TITLE
Remove unnecessary packaged dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,6 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "vue": "^3.4.1",
-    "vue-i18n": "^9.8.0",
-    "vue-router": "^4.2.5",
     "@babel/core": "^7.23.7",
     "@babel/eslint-parser": "^7.23.3",
     "@babel/plugin-syntax-import-assertions": "^7.23.3",
@@ -64,6 +61,9 @@
     "vite": "^5.0.10",
     "vite-electron-plugin": "^0.8.3",
     "vite-plugin-electron-renderer": "^0.14.5",
-    "vite-plugin-eslint": "^1.8.1"
+    "vite-plugin-eslint": "^1.8.1",
+    "vue": "^3.4.1",
+    "vue-i18n": "^9.8.0",
+    "vue-router": "^4.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "music-metadata-browser": "^2.5.10",
     "pinia": "^2.1.7",
     "slick-carousel": "^1.8.1",
-    "uuid": "^9.0.1",
-    "vue": "^3.4.1",
-    "vue-i18n": "^9.8.0",
-    "vue-router": "^4.2.5"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "vue": "^3.4.1",
+    "vue-i18n": "^9.8.0",
+    "vue-router": "^4.2.5",
     "@babel/core": "^7.23.7",
     "@babel/eslint-parser": "^7.23.3",
     "@babel/plugin-syntax-import-assertions": "^7.23.3",


### PR DESCRIPTION
Vue is not required after building. This reduces packaged app size by ~1.8 MB. Please test a build before merging.