### PR TITLE
Implement About Window For Linux

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -18,7 +18,7 @@
     ]
   },
   "linux": {
-    "category": "Audio",
+    "category": "AudioVideo",
     "icon": "build/icons/icon.icns",
     "target": [
       "AppImage",
@@ -26,7 +26,14 @@
       "flatpak",
       "pacman",
       "rpm"
-    ]
+    ],
+    "desktop": {
+      "Actions": "about;",
+      "Categories": "AudioVideo",
+      "Comment": "Advanced multi-source music streaming + discovery client",
+      "MimeType": "x-scheme-handler/muffon;",
+      "\n\n[Desktop Action about]\nName=About\nExec": "/opt/muffon/muffon --open-about-window\n\n"
+    }
   },
   "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
   "compression": "ultra",
@@ -41,7 +48,7 @@
     "baseVersion": "23.08"
   },
   "portable": {
-    "artifactName": "${productName}-${version}-${os}-${arch}-portable.${ext}",
+    "artifactName": "${productName}-${version}-${os}-${arch}-portable.${ext}"
   },
   "directories": {
     "buildResources": "build",

--- a/electron/actions/app/setup.js
+++ b/electron/actions/app/setup.js
@@ -1,4 +1,6 @@
-import { app } from 'electron'
+import {
+  app
+} from 'electron'
 import createMainWindow
   from '../../actions/mainWindow/create.js'
 import createAboutWindow
@@ -15,7 +17,9 @@ export default function () {
 
   createAboutWindow()
 
-  if (app.commandLine.hasSwitch('open-about-window')) {
+  if (app.commandLine.hasSwitch(
+    'open-about-window'
+  )) {
     aboutWindow.show()
   }
 

--- a/electron/actions/app/setup.js
+++ b/electron/actions/app/setup.js
@@ -1,3 +1,4 @@
+import { app } from 'electron'
 import createMainWindow
   from '../../actions/mainWindow/create.js'
 import createAboutWindow
@@ -13,6 +14,10 @@ export default function () {
   createMainWindow()
 
   createAboutWindow()
+
+  if (app.commandLine.hasSwitch('open-about-window')) {
+    aboutWindow.show()
+  }
 
   const isWithTrayIcon =
     getElectronStoreKey(

--- a/electron/handlers/app.js
+++ b/electron/handlers/app.js
@@ -44,14 +44,13 @@ export function handleSecondInstance (
   args
 ) {
   if (mainWindow) {
-    mainWindow.show()
-
-    mainWindow.focus()
-
     if (args && args.includes(
       '--open-about-window'
     )) {
       aboutWindow.show()
+    } else {
+      mainWindow.show()
+      mainWindow.focus()
     }
   }
 

--- a/electron/handlers/app.js
+++ b/electron/handlers/app.js
@@ -47,6 +47,12 @@ export function handleSecondInstance (
     mainWindow.show()
 
     mainWindow.focus()
+
+    if (args && args.includes(
+      '--open-about-window'
+    )) {
+      aboutWindow.show()
+    }
   }
 
   if (isWindows || isLinux) {


### PR DESCRIPTION
Until now, there was no option to show the about window on linux. Now, users can open the about window by right clicking on the application in the dock. This is done by setting up custom actions in the .desktop file.