### PR TITLE
Add Vietnamese (vi) localization support

### DIFF
--- a/electron/plugins/i18n.js
+++ b/electron/plugins/i18n.js
@@ -13,6 +13,7 @@ import pl from './i18n/locales/pl.json' with { type: 'json' }
 import ptBr from './i18n/locales/pt_BR.json' with { type: 'json' }
 import ru from './i18n/locales/ru.json' with { type: 'json' }
 import tr from './i18n/locales/tr.json' with { type: 'json' }
+import vi from './i18n/locales/vi.json' with { type: 'json' }
 import zh from './i18n/locales/zh.json' with { type: 'json' }
 
 // i18n
@@ -36,6 +37,7 @@ const localesData = {
   pt_BR: ptBr,
   ru,
   tr,
+  vi,
   zh
 }
 

--- a/electron/plugins/i18n/locales/vi.json
+++ b/electron/plugins/i18n/locales/vi.json
@@ -1,0 +1,13 @@
+{
+  "show": "Hiển thị",
+  "hide": "Ẩn",
+  "about": "Giới thiệu",
+  "quit": "Thoát",
+  "update": {
+    "message": "Phiên bản mới đã có sẵn",
+    "buttons": {
+      "download": "Tải xuống",
+      "close": "Đóng"
+    }
+  }
+}

--- a/src/helpers/data/locales.js
+++ b/src/helpers/data/locales.js
@@ -55,6 +55,10 @@ export default [
     name: 'Türkçe'
   },
   {
+    id: 'vi',
+    name: 'Tiếng Việt'
+  },
+  {
     id: 'zh',
     name: '中文'
   }

--- a/src/plugins/dayjs.js
+++ b/src/plugins/dayjs.js
@@ -16,6 +16,7 @@ import 'dayjs/locale/pl'
 import 'dayjs/locale/pt-br'
 import 'dayjs/locale/ru'
 import 'dayjs/locale/tr'
+import 'dayjs/locale/vi'
 import 'dayjs/locale/zh'
 
 // i18n

--- a/src/plugins/i18n.js
+++ b/src/plugins/i18n.js
@@ -14,6 +14,7 @@ import pl from './i18n/locales/pl.json'
 import ptBr from './i18n/locales/pt_BR.json'
 import ru from './i18n/locales/ru.json'
 import tr from './i18n/locales/tr.json'
+import vi from './i18n/locales/vi.json'
 import zh from './i18n/locales/zh.json'
 import slavicPluralizationRule
   from './i18n/rules/pluralization/slavic.js'
@@ -34,6 +35,7 @@ const localesData = {
   pt_BR: ptBr,
   ru,
   tr,
+  vi,
   zh
 }
 
@@ -178,6 +180,16 @@ if (import.meta.hot) {
     fileImport => {
       i18n.global.setLocaleMessage(
         'tr',
+        fileImport.default
+      )
+    }
+  )
+
+  import.meta.hot.accept(
+    './i18n/locales/vi.json',
+    fileImport => {
+      i18n.global.setLocaleMessage(
+        'vi',
         fileImport.default
       )
     }

--- a/src/plugins/i18n/locales/vi.json
+++ b/src/plugins/i18n/locales/vi.json
@@ -1,0 +1,948 @@
+{
+  "navigation": {
+    "home": "Trang chủ",
+    "artists": "Nghệ sĩ",
+    "artist": "Nghệ sĩ",
+    "albums": "Album",
+    "albumGroups": "Nhóm album",
+    "tracks": "Bài hát",
+    "tags": "Thẻ",
+    "tag": "Thẻ",
+    "similar": "Tương tự",
+    "images": "Hình ảnh",
+    "lyrics": "Lời bài hát",
+    "videos": "Video",
+    "videoChannels": "Kênh video",
+    "videoMixes": "Video mix",
+    "videoPlaylists": "Danh sách phát video",
+    "top": "Hàng đầu",
+    "topCollection": {
+      "artists": "Nghệ sĩ hàng đầu",
+      "albums": "Album hàng đầu",
+      "tracks": "Bài hát hàng đầu",
+      "tags": "Thẻ hàng đầu"
+    },
+    "releases": "Phát hành",
+    "releasesCollection": {
+      "new": "Phát hành mới",
+      "upcoming": "Sắp phát hành"
+    },
+    "new": "Mới",
+    "upcoming": "Sắp ra mắt",
+    "radio": "Radio",
+    "multitag": "Tìm kiếm đa thẻ",
+    "profiles": "Hồ sơ",
+    "feed": "Bảng tin",
+    "posts": "Bài viết",
+    "conversations": "Cuộc trò chuyện",
+    "library": "Thư viện",
+    "recommendations": "Đề xuất",
+    "recommendationsCollection": {
+      "artists": "Nghệ sĩ được đề xuất",
+      "tracks": "Bài hát được đề xuất"
+    },
+    "savedTracks": "Bài hát đã lưu",
+    "playlists": "Danh sách phát",
+    "favorites": "Yêu thích",
+    "bookmarks": "Đánh dấu",
+    "bookmarksCollection": {
+      "artists": "Nghệ sĩ đã đánh dấu",
+      "albums": "Album đã đánh dấu",
+      "tracks": "Bài hát đã đánh dấu",
+      "videos": "Video đã đánh dấu",
+      "videoChannels": "Kênh video đã đánh dấu",
+      "videoPlaylists": "Danh sách phát video đã đánh dấu"
+    },
+    "communities": "Cộng đồng",
+    "history": "Lịch sử",
+    "historyCollection": {
+      "activity": "Lịch sử hoạt động",
+      "player": "Lịch sử phát",
+      "browser": "Lịch sử trình duyệt"
+    },
+    "activity": "Hoạt động",
+    "player": "Trình phát",
+    "browser": "Trình duyệt",
+    "settings": "Cài đặt",
+    "model": {
+      "artists": "Nghệ sĩ {modelName}",
+      "albums": "Album {modelName}",
+      "tracks": "Bài hát {modelName}",
+      "tags": "Thẻ {modelName}",
+      "similar": "Tương tự {modelName}",
+      "images": "Hình ảnh {modelName}",
+      "lyrics": "Lời bài hát {modelName}",
+      "videos": "Video {modelName}",
+      "posts": "Bài viết {modelName}",
+      "library": "Thư viện {modelName}",
+      "playlists": "Danh sách phát {modelName}",
+      "favorites": "Yêu thích {modelName}",
+      "favoritesCollection": {
+        "artists": "Nghệ sĩ yêu thích {modelName}",
+        "albums": "Album yêu thích {modelName}",
+        "tracks": "Bài hát yêu thích {modelName}",
+        "videos": "Video yêu thích {modelName}"
+      },
+      "communities": "Cộng đồng {modelName}",
+      "shows": "Chương trình {modelName}"
+    },
+    "search": "Tìm kiếm",
+    "queue": "Hàng đợi",
+    "whatsNew": "Có gì mới",
+    "listenedRecently": "Nghe gần đây",
+    "shows": "Chương trình",
+    "listeningNow": "Đang nghe",
+    "help": "Trợ giúp"
+  },
+  "errors": {
+    "badRequest": {
+      "header": "Yêu cầu không hợp lệ",
+      "content": "Vui lòng gửi yêu cầu với dữ liệu hợp lệ"
+    },
+    "forbidden": {
+      "header": "Bị cấm",
+      "content": "Bạn không có quyền thực hiện hành động này"
+    },
+    "notFound": {
+      "header": "Không tìm thấy gì",
+      "content": "Vui lòng thử tìm kiếm thứ khác"
+    },
+    "internalServer": {
+      "header": "Lỗi máy chủ nội bộ",
+      "content": "Vui lòng liên hệ với chúng tôi để biết thông tin"
+    },
+    "badGateway": {
+      "header": "Lỗi máy chủ từ xa",
+      "content": "Vui lòng thử lại sau"
+    },
+    "gatewayTimeout": {
+      "header": "Hết thời gian chờ máy chủ từ xa",
+      "content": "Vui lòng thử lại sau"
+    },
+    "connection": {
+      "header": "Mất kết nối",
+      "content": "Vui lòng thử lại sau"
+    },
+    "client": {
+      "header": "Lỗi máy khách",
+      "content": "Vui lòng liên hệ với chúng tôi để biết thông tin"
+    }
+  },
+  "actions": {
+    "login": "Đăng nhập",
+    "logout": "Đăng xuất",
+    "signup": "Đăng ký",
+    "add": "Thêm",
+    "create": "Tạo",
+    "edit": "Chỉnh sửa",
+    "save": "Lưu",
+    "cancel": "Hủy",
+    "delete": "Xóa",
+    "clear": "Xóa sạch",
+    "retry": "Thử lại",
+    "post": "Đăng",
+    "send": "Gửi",
+    "next": "Tiếp theo",
+    "upload": "Tải lên",
+    "back": "Quay lại",
+    "sendCode": "Gửi mã",
+    "share": "Chia sẻ",
+    "search": "Tìm kiếm",
+    "filter": "Lọc",
+    "confirm": "Xác nhận",
+    "import": "Nhập",
+    "close": "Đóng",
+    "openLink": "Mở liên kết",
+    "play": "Phát",
+    "shuffle": "Phát ngẫu nhiên",
+    "loop": "Lặp lại",
+    "addFrom": {
+      "search": "Từ tìm kiếm",
+      "library": "Từ thư viện"
+    },
+    "importFrom": {
+      "drive": "Từ ổ đĩa",
+      "account": "Từ tài khoản"
+    },
+    "searchIn": {
+      "source": "Tìm trong nguồn",
+      "sources": "Tìm trong các nguồn"
+    },
+    "searchFor": {
+      "video": "Tìm video",
+      "lyrics": "Tìm lời bài hát"
+    },
+    "importFromAccount": {
+      "lastfm": "Nhập từ Last.FM",
+      "spotify": "Nhập từ Spotify"
+    },
+    "selectModel": {
+      "folder": "Chọn thư mục"
+    },
+    "createModel": {
+      "playlist": "Tạo danh sách phát",
+      "community": "Tạo cộng đồng",
+      "post": "Tạo bài viết"
+    },
+    "addModel": {
+      "comment": "Thêm bình luận"
+    },
+    "addTo": {
+      "library": "Thêm vào thư viện",
+      "playlist": "Thêm vào danh sách phát",
+      "favorites": "Thêm vào yêu thích",
+      "bookmarks": "Thêm vào đánh dấu",
+      "listened": "Thêm vào đã nghe",
+      "watched": "Thêm vào đã xem",
+      "queue": "Thêm vào hàng đợi",
+      "savedTracks": "Thêm vào bài hát đã lưu"
+    },
+    "goTo": {
+      "video": "Đi đến trang video",
+      "library": "Đi đến trang thư viện",
+      "page": "Đi đến trang"
+    },
+    "deleteFrom": {
+      "favorites": "Xóa khỏi yêu thích",
+      "bookmarks": "Xóa khỏi đánh dấu",
+      "listened": "Xóa khỏi đã nghe",
+      "watched": "Xóa khỏi đã xem"
+    },
+    "externalLink": {
+      "open": "Mở liên kết bên ngoài",
+      "original": "Gốc",
+      "streaming": "Phát trực tuyến"
+    }
+  },
+  "links": {
+    "playlists": "Tất cả danh sách phát",
+    "communities": "Tất cả cộng đồng"
+  },
+  "inputs": {
+    "search": "Tìm kiếm...",
+    "content": "Viết gì đó..."
+  },
+  "modals": {
+    "delete": {
+      "header": {
+        "libraryModel": {
+          "artist": "Xóa nghệ sĩ khỏi thư viện",
+          "album": "Xóa album khỏi thư viện",
+          "track": "Xóa bài hát khỏi thư viện"
+        },
+        "recommendationModel": {
+          "artist": "Xóa nghệ sĩ khỏi đề xuất",
+          "track": "Xóa bài hát khỏi đề xuất"
+        },
+        "playlist": "Xóa danh sách phát",
+        "playlistTrack": "Xóa bài hát khỏi danh sách phát",
+        "savedTrack": "Xóa bài hát khỏi bài hát đã lưu",
+        "favorite": {
+          "artist": "Xóa nghệ sĩ khỏi yêu thích",
+          "album": "Xóa album khỏi yêu thích",
+          "track": "Xóa bài hát khỏi yêu thích",
+          "video": "Xóa video khỏi yêu thích"
+        },
+        "bookmark": {
+          "artist": "Xóa nghệ sĩ khỏi đánh dấu",
+          "album": "Xóa album khỏi đánh dấu",
+          "track": "Xóa bài hát khỏi đánh dấu",
+          "video": "Xóa video khỏi đánh dấu",
+          "videoChannel": "Xóa kênh video khỏi đánh dấu",
+          "videoPlaylist": "Xóa danh sách phát video khỏi đánh dấu"
+        },
+        "post": "Xóa bài viết",
+        "comment": "Xóa bình luận",
+        "community": "Xóa cộng đồng",
+        "account": "Xóa tài khoản",
+        "library": "Xóa thư viện",
+        "history": {
+          "search": "Xóa lịch sử tìm kiếm",
+          "activity": "Xóa lịch sử hoạt động",
+          "browser": "Xóa lịch sử trình duyệt",
+          "player": "Xóa lịch sử phát"
+        }
+      },
+      "going": {
+        "libraryModel": "Bạn sắp xóa {modelName} khỏi thư viện của bạn.",
+        "recommendationModel": "Bạn sắp xóa {modelName} khỏi đề xuất của bạn.",
+        "playlist": "Bạn sắp xóa {modelName} khỏi danh sách phát của bạn.",
+        "playlistTrack": "Bạn sắp xóa {modelName} khỏi danh sách phát {parentModelName}.",
+        "savedTrack": "Bạn sắp xóa {modelName} khỏi bài hát đã lưu của bạn.",
+        "favorite": "Bạn sắp xóa {modelName} khỏi yêu thích của bạn.",
+        "bookmark": "Bạn sắp xóa {modelName} khỏi đánh dấu của bạn.",
+        "post": "Bạn sắp xóa bài viết này.",
+        "comment": "Bạn sắp xóa bình luận này.",
+        "community": "Bạn sắp xóa cộng đồng này.",
+        "account": "Bạn sắp xóa tài khoản của bạn.",
+        "library": "Bạn sắp xóa thư viện của bạn.",
+        "history": {
+          "search": "Bạn sắp xóa lịch sử tìm kiếm của bạn.",
+          "activity": "Bạn sắp xóa lịch sử hoạt động của bạn.",
+          "browser": "Bạn sắp xóa lịch sử trình duyệt của bạn.",
+          "player": "Bạn sắp xóa lịch sử phát của bạn."
+        }
+      },
+      "also": {
+        "libraryModel": {
+          "artist": "Điều này cũng sẽ xóa tất cả album và bài hát của nghệ sĩ này.",
+          "album": "Điều này cũng sẽ xóa tất cả bài hát của album này."
+        },
+        "playlist": "Điều này cũng sẽ xóa tất cả bài hát của danh sách phát này.",
+        "community": "Điều này cũng sẽ xóa tất cả bài viết của cộng đồng này.",
+        "account": [
+          "Điều này cũng sẽ xóa dữ liệu sau:",
+          "<strong>- thư viện\n- đề xuất\n- danh sách phát\n- yêu thích\n- đánh dấu\n- đã nghe\n- bài viết trang\n- đăng ký\n- lịch sử</strong>",
+          "Dữ liệu này sẽ được giữ lại, nhưng biệt danh của bạn sẽ không được hiển thị:",
+          "<strong>- bài viết đã tạo\n- bình luận đã tạo\n- cuộc trò chuyện với bạn\n- cộng đồng đã tạo</strong>",
+          "Và dữ liệu này sẽ không thay đổi:",
+          "<strong>- bài hát đã lưu\n- hình nền\n- cài đặt</strong>"
+        ],
+        "library": [
+          "Điều này sẽ xóa dữ liệu sau:",
+          "<strong>- nghệ sĩ\n- album\n- bài hát\n- đề xuất</strong>"
+        ]
+      },
+      "undo": "Bạn không thể hoàn tác hành động này!",
+      "sure": "Bạn có chắc chắn không?"
+    }
+  },
+  "forms": {
+    "fields": {
+      "email": "Email",
+      "password": "Mật khẩu",
+      "passwordConfirmation": "Xác nhận mật khẩu",
+      "passwordResetCode": "Mã đặt lại mật khẩu",
+      "nickname": "Biệt danh",
+      "title": "Tiêu đề",
+      "description": "Mô tả",
+      "gender": "Giới tính",
+      "birthdate": "Ngày sinh",
+      "country": "Quốc gia",
+      "city": "Thành phố",
+      "status": "Trạng thái",
+      "clientId": "ID máy khách",
+      "clientSecret": "Mã bí mật máy khách",
+      "genders": {
+        "male": "Nam",
+        "female": "Nữ",
+        "other": "Khác"
+      },
+      "legal": {
+        "header": "Tôi đồng ý với {privacyPolicy} và {termsAndConditions}",
+        "privacyPolicy": "Chính sách bảo mật",
+        "termsAndConditions": "Điều khoản và điều kiện"
+      },
+      "remember": "Ghi nhớ đăng nhập",
+      "asCommunity": "Với tư cách cộng đồng"
+    },
+    "extra": "Thông tin bổ sung",
+    "errors": {
+      "notFound": "Không tìm thấy hồ sơ",
+      "empty": {
+        "email": "Email trống",
+        "password": "Mật khẩu trống",
+        "passwordConfirmation": "Xác nhận mật khẩu trống",
+        "passwordResetCode": "Mã đặt lại mật khẩu trống",
+        "nickname": "Biệt danh trống",
+        "title": "Tiêu đề trống",
+        "clientId": "ID máy khách trống",
+        "clientSecret": "Mã bí mật máy khách trống",
+        "legal": "Bạn phải đồng ý với Chính sách bảo mật và Điều khoản và điều kiện"
+      },
+      "invalid": {
+        "email": "Email không hợp lệ"
+      },
+      "taken": {
+        "email": "Email đã được sử dụng",
+        "nickname": "Biệt danh đã được sử dụng",
+        "title": "Tiêu đề đã được sử dụng"
+      },
+      "tooShort": {
+        "password": "Mật khẩu quá ngắn"
+      },
+      "tooLong": {
+        "nickname": "Biệt danh quá dài"
+      },
+      "confirmation": {
+        "passwordConfirmation": "Mật khẩu và xác nhận không khớp"
+      },
+      "wrong": {
+        "password": "Mật khẩu sai",
+        "passwordResetCode": "Mã đặt lại mật khẩu sai"
+      }
+    },
+    "confirm": {
+      "password": "Vui lòng xác nhận mật khẩu của bạn:"
+    }
+  },
+  "notifications": {
+    "scrobbled": "Bài hát {trackFullTitle} đã được scrobble",
+    "added": {
+      "queue": {
+        "track": "Bài hát {trackFullTitle} đã được thêm vào hàng đợi",
+        "tracks": "{counter} đã được thêm vào hàng đợi | {counter} đã được thêm vào hàng đợi"
+      },
+      "savedTracks": {
+        "track": "Bài hát {trackFullTitle} đã được thêm vào bài hát đã lưu"
+      }
+    },
+    "updated": {
+      "profile": "Hồ sơ đã được cập nhật",
+      "post": "Bài viết đã được cập nhật",
+      "comment": "Bình luận đã được cập nhật",
+      "playlist": "Danh sách phát {playlistTitle} đã được cập nhật",
+      "community": "Cộng đồng {communityTitle} đã được cập nhật"
+    },
+    "deleted": {
+      "libraryModel": {
+        "artist": "Nghệ sĩ {modelName} đã được xóa khỏi thư viện của bạn",
+        "album": "Album {modelName} đã được xóa khỏi thư viện của bạn",
+        "track": "Bài hát {modelName} đã được xóa khỏi thư viện của bạn"
+      },
+      "playlist": "Danh sách phát {playlistTitle} đã được xóa",
+      "community": "Cộng đồng {communityTitle} đã được xóa",
+      "account": "Tài khoản của bạn đã được xóa",
+      "library": "Thư viện của bạn đã được xóa",
+      "history": {
+        "search": "Lịch sử tìm kiếm đã được xóa",
+        "activity": "Lịch sử hoạt động đã được xóa",
+        "browser": "Lịch sử trình duyệt đã được xóa",
+        "player": "Lịch sử phát đã được xóa"
+      }
+    },
+    "copied": "Liên kết đã được sao chép vào clipboard",
+    "cleared": {
+      "cache": "Bộ nhớ cache đã được xóa",
+      "searchHistory": "Lịch sử tìm kiếm đã được xóa"
+    },
+    "restartToApply": "Cài đặt đã được lưu và sẽ được áp dụng khi khởi động lại ứng dụng"
+  },
+  "counters": {
+    "nominative": {
+      "artists": "{count} nghệ sĩ | {count} nghệ sĩ",
+      "albums": "{count} album | {count} album",
+      "tracks": "{count} bài hát | {count} bài hát",
+      "videos": "{count} video | {count} video",
+      "files": "{count} tệp | {count} tệp",
+      "plays": "{count} lượt phát | {count} lượt phát",
+      "followers": "{count} người theo dõi | {count} người theo dõi",
+      "following": "{count} đang theo dõi",
+      "members": "{count} thành viên | {count} thành viên",
+      "playlists": "{count} danh sách phát | {count} danh sách phát"
+    },
+    "genitive": {
+      "artists": "{count} nghệ sĩ | {count} nghệ sĩ",
+      "albums": "{count} album | {count} album",
+      "tracks": "{count} bài hát | {count} bài hát",
+      "files": "{count} tệp | {count} tệp",
+      "plays": "{count} lượt phát | {count} lượt phát",
+      "playlists": "{count} danh sách phát | {count} danh sách phát"
+    },
+    "accusative": {
+      "artists": "{count} nghệ sĩ | {count} nghệ sĩ",
+      "albums": "{count} album | {count} album",
+      "tracks": "{count} bài hát | {count} bài hát",
+      "files": "{count} tệp | {count} tệp",
+      "playlists": "{count} danh sách phát | {count} danh sách phát"
+    }
+  },
+  "select": {
+    "source": "Chọn nguồn:",
+    "type": "Chọn loại:",
+    "album": "Chọn album:",
+    "group": "Chọn nhóm album:",
+    "artist": "Chọn nghệ sĩ:",
+    "track": "Chọn bài hát:",
+    "country": "Chọn quốc gia:",
+    "video": "Chọn video:",
+    "lyrics": "Chọn lời bài hát:"
+  },
+  "sources": {
+    "audio": "Âm thanh",
+    "other": "Khác",
+    "albumTypes": {
+      "album": "Album",
+      "group": "Nhóm album",
+      "track": "Bài hát"
+    },
+    "albumsTypes": {
+      "album": "Album",
+      "single": "Đĩa đơn",
+      "ep": "EP",
+      "singleEp": "Đĩa đơn / EP",
+      "compilation": "Tuyển tập",
+      "video": "Video",
+      "misc": "Linh tinh",
+      "appearance": "Xuất hiện",
+      "live": "Trực tiếp"
+    }
+  },
+  "player": {
+    "variants": "Biến thể ({count})",
+    "audio": {
+      "bitrate": "{value} kbit/s",
+      "equalizer": {
+        "decibel": "{value} dB",
+        "hertz": "{value} Hz",
+        "kilohertz": "{value} kHz"
+      }
+    }
+  },
+  "settings": {
+    "tabs": {
+      "app": "Ứng dụng",
+      "profile": "Hồ sơ",
+      "connections": "Kết nối"
+    },
+    "sections": {
+      "interface": "Giao diện",
+      "theme": "Chủ đề",
+      "window": "Cửa sổ",
+      "tabs": "Tab",
+      "sidebar": "Thanh bên",
+      "video": "Video",
+      "data": "Dữ liệu",
+      "info": "Thông tin",
+      "account": "Tài khoản",
+      "system": "Hệ thống",
+      "updates": "Cập nhật"
+    },
+    "options": {
+      "app": {
+        "interface": {
+          "language": "Ngôn ngữ",
+          "timezone": "Múi giờ",
+          "infiniteScroll": "Cuộn vô hạn",
+          "artistPopup": "Hiển thị thông tin nghệ sĩ khi di chuột qua liên kết",
+          "innerCounters": "Hiển thị bộ đếm người nghe muffon",
+          "cachePages": "Lưu cache trang",
+          "scale": "Tỷ lệ"
+        },
+        "theme": {
+          "dark": "Chế độ tối",
+          "system": "Chủ đề hệ thống",
+          "background": "Hình nền",
+          "transparency": "Độ trong suốt"
+        },
+        "window": {
+          "maximize": "Phóng to khi khởi động",
+          "quit": "Thoát khi đóng",
+          "showTrayIcon": "Hiển thị biểu tượng khay"
+        },
+        "tabs": {
+          "newTabSwitch": "Chuyển sang tab mới",
+          "closeOnQuit": "Đóng tab khi thoát"
+        },
+        "search": {
+          "source": "Nguồn",
+          "scope": "Phạm vi",
+          "resultsFullSize": "Hiển thị kết quả ở kích thước đầy đủ"
+        },
+        "player": {
+          "audioSources": "Nguồn âm thanh (theo thứ tự ưu tiên)",
+          "automatch": "Khớp âm thanh với bài hát",
+          "bitrate": "Hiển thị bitrate âm thanh",
+          "album": "Hiển thị album",
+          "equalizer": "Hiển thị bộ cân bằng",
+          "focusPlaying": "Tập trung vào bài hát hiện tại",
+          "pauseOnVideoPlay": "Tạm dừng khi phát video"
+        },
+        "queue": {
+          "autoplay": "Tự động phát",
+          "clear": "Xóa khi đóng trình phát"
+        },
+        "video": {
+          "autoplay": "Tự động phát",
+          "pauseOnAudioPlay": "Tạm dừng khi phát âm thanh",
+          "openLinksInNewTab": "Mở liên kết trong tab mới"
+        },
+        "recommendations": {
+          "hideLibraryArtists": "Ẩn nghệ sĩ trong thư viện",
+          "tracksCount": "với số lượng bài hát",
+          "hideListenedArtists": "Ẩn nghệ sĩ đã nghe",
+          "hideLibraryTracks": "Ẩn bài hát trong thư viện",
+          "hideListenedTracks": "Ẩn bài hát đã nghe"
+        },
+        "top": {
+          "country": "Quốc gia mặc định"
+        },
+        "lyrics": {
+          "annotations": "Hiển thị chú thích"
+        },
+        "history": {
+          "search": {
+            "delete": "Xóa lịch sử tìm kiếm"
+          },
+          "activity": {
+            "save": "Lưu lịch sử hoạt động",
+            "delete": "Xóa lịch sử hoạt động"
+          },
+          "player": {
+            "save": "Lưu lịch sử phát",
+            "delete": "Xóa lịch sử phát"
+          },
+          "browser": {
+            "save": "Lưu lịch sử trình duyệt",
+            "delete": "Xóa lịch sử trình duyệt"
+          }
+        },
+        "system": {
+          "cache": {
+            "enable": "Bật cache",
+            "clear": "Xóa cache"
+          }
+        },
+        "updates": {
+          "check": "Kiểm tra phiên bản mới",
+          "auto": "Bật tự động cập nhật",
+          "autoWarning": "Tự động cập nhật trên Linux vẫn đang trong giai đoạn thử nghiệm và có thể chứa lỗi.\nTrong quá trình tự động cập nhật, ứng dụng sẽ tạm thời bị đóng băng.\nVui lòng tránh buộc thoát ứng dụng; nó sẽ tự động đóng khi hoàn tất cập nhật.\n\nĐể biết chi tiết và theo dõi vấn đề này, vui lòng truy cập [a link=issue]liên kết này[/a]."
+        }
+      },
+      "profile": {
+        "player": {
+          "playing": "Hiển thị bài hát hiện tại trên trang"
+        },
+        "data": {
+          "account": {
+            "delete": "Xóa tài khoản"
+          },
+          "library": {
+            "delete": "Xóa thư viện"
+          }
+        }
+      },
+      "connections": {
+        "lastfm": {
+          "scrobbling": "Scrobbling",
+          "scrobbleNotifications": "Thông báo scrobble",
+          "scrobblePercent": "Scrobble sau"
+        },
+        "spotify": {
+          "link": {
+            "description": "Để kết nối tài khoản Spotify của bạn, vui lòng làm theo [a link=guide]hướng dẫn này[/a]."
+          }
+        },
+        "discord": {
+          "richPresence": {
+            "header": "Bật Rich Presence",
+            "client": "Trước khi bật, hãy đảm bảo ứng dụng Discord desktop của bạn đang chạy",
+            "buttons": {
+              "header": "Nút",
+              "select": {
+                "first": "Chọn nút đầu tiên:",
+                "second": "Chọn nút thứ hai:"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "track": {
+    "source": "Qua {source}"
+  },
+  "recommended": {
+    "header": "Được đề xuất cho bạn",
+    "based": "Dựa trên:"
+  },
+  "signup": {
+    "text": "Chưa có tài khoản?",
+    "link": "Đăng ký"
+  },
+  "login": {
+    "text": "Đã đăng ký?",
+    "link": "Đăng nhập"
+  },
+  "passwordReset": {
+    "text": "Quên mật khẩu?",
+    "link": "Đặt lại",
+    "code": {
+      "sent": "Mã đặt lại mật khẩu đã được gửi đến email của bạn"
+    },
+    "updated": {
+      "header": "Mật khẩu của bạn đã được cập nhật",
+      "content": "Bây giờ bạn có thể quay lại và đăng nhập"
+    }
+  },
+  "anonymous": {
+    "continue": "Tiếp tục ẩn danh",
+    "nickname": "Ẩn danh"
+  },
+  "roles": {
+    "creator": "Người tạo"
+  },
+  "relationships": {
+    "followed": "Đang theo dõi bạn",
+    "following": "Bạn đang theo dõi",
+    "follow": "Theo dõi",
+    "unfollow": "Bỏ theo dõi"
+  },
+  "memberships": {
+    "joined": "Bạn đã tham gia",
+    "join": "Tham gia",
+    "leave": "Rời khỏi"
+  },
+  "message": {
+    "send": "Gửi tin nhắn",
+    "sent": {
+      "header": "Tin nhắn đã được gửi",
+      "content": "Đi đến cuộc trò chuyện"
+    }
+  },
+  "compatibility": {
+    "header": "Mức độ tương thích của bạn với {profileNickname}",
+    "common": "Bạn có điểm chung:"
+  },
+  "recommendation": {
+    "similar": "Tương tự với {counter}:"
+  },
+  "import": {
+    "lastfm": {
+      "historyVisible": "Trước khi nhập, hãy đảm bảo lịch sử nghe nhạc Last.FM của bạn hiển thị."
+    },
+    "active": "Đang nhập {count} trong số {counter}...",
+    "success": {
+      "header": {
+        "files": "{counter} đã được nhập | {counter} đã được nhập",
+        "tracks": "{counter} đã được nhập | {counter} đã được nhập",
+        "playlists": "{counter} đã được nhập | {counter} đã được nhập"
+      },
+      "content": "Bạn có thể muốn kiểm tra dữ liệu trước khi lưu vào thư viện"
+    },
+    "error": {
+      "files": "{counter} không thể nhập. Vui lòng đảm bảo định dạng metadata hợp lệ:"
+    }
+  },
+  "save": {
+    "active": "Đang lưu {count} trong số {counter}...",
+    "success": {
+      "library": {
+        "artists": "{counter} đã được thêm vào thư viện | {counter} đã được thêm vào thư viện",
+        "albums": "{counter} đã được thêm vào thư viện | {counter} đã được thêm vào thư viện",
+        "tracks": "{counter} đã được thêm vào thư viện | {counter} đã được thêm vào thư viện"
+      },
+      "playlist": {
+        "artists": "{counter} đã được thêm vào danh sách phát | {counter} đã được thêm vào danh sách phát",
+        "albums": "{counter} đã được thêm vào danh sách phát | {counter} đã được thêm vào danh sách phát",
+        "tracks": "{counter} đã được thêm vào danh sách phát | {counter} đã được thêm vào danh sách phát"
+      },
+      "playlists": {
+        "playlists": "{counter} đã được thêm vào danh sách phát | {counter} đã được thêm vào danh sách phát"
+      },
+      "favorites": {
+        "tracks": "{counter} đã được thêm vào yêu thích | {counter} đã được thêm vào yêu thích"
+      }
+    },
+    "error": "{counter} không thể thêm:"
+  },
+  "delete": {
+    "active": "Đang xóa {count} trong số {counter}..."
+  },
+  "connections": {
+    "connect": "Kết nối tài khoản",
+    "confirm": {
+      "token": "Trình duyệt của bạn sẽ mở. Xác nhận kết nối ở đó và nhấp lại nút này.",
+      "code": "Trình duyệt của bạn sẽ mở. Xác nhận kết nối ở đó, dán mã nhận được và nhấp lại nút này."
+    },
+    "disconnect": "Ngắt kết nối tài khoản"
+  },
+  "accounts": {
+    "premium": "Cao cấp"
+  },
+  "noCollection": {
+    "header": {
+      "artists": "Không có nghệ sĩ",
+      "albums": "Không có album",
+      "groups": "Không có nhóm album",
+      "tracks": "Không có bài hát",
+      "similar": "Không có tương tự",
+      "tags": "Không có thẻ",
+      "posts": "Không có bài viết",
+      "feed": "Không có bài viết",
+      "conversations": "Không có cuộc trò chuyện",
+      "messages": "Không có tin nhắn",
+      "followers": "Không có người theo dõi",
+      "following": "Không theo dõi ai",
+      "recommendations": "Không có đề xuất",
+      "playlists": "Không có danh sách phát",
+      "communities": "Không có cộng đồng",
+      "members": "Không có thành viên",
+      "videos": "Không có video",
+      "videoChannels": "Không có kênh video",
+      "videoMixes": "Không có video mix",
+      "videoPlaylists": "Không có danh sách phát video",
+      "listeners": "Không có người nghe",
+      "images": "Không có hình ảnh",
+      "events": "Không có sự kiện",
+      "profiles": "Không có hồ sơ",
+      "shows": "Không có chương trình",
+      "pages": "Không có trang",
+      "lyrics": "Không có lời bài hát"
+    },
+    "content": "Có vẻ như không có gì ở đây"
+  },
+  "deleted": {
+    "artist": "Nghệ sĩ đã bị xóa",
+    "album": "Album đã bị xóa",
+    "track": "Bài hát đã bị xóa",
+    "recommendation": "Đề xuất đã bị xóa",
+    "playlist": "Danh sách phát đã bị xóa",
+    "post": "Bài viết đã bị xóa",
+    "comment": "Bình luận đã bị xóa",
+    "video": "Video đã bị xóa",
+    "videoChannel": "Kênh video đã bị xóa",
+    "videoPlaylist": "Danh sách phát video đã bị xóa"
+  },
+  "messages": {
+    "welcome": "Chào mừng, {profileNickname}"
+  },
+  "profile": {
+    "wasOnline": "Đã online"
+  },
+  "feed": {
+    "global": "Bảng tin toàn cầu"
+  },
+  "about": {
+    "license": "Giấy phép {license}",
+    "homepage": "Trang chủ",
+    "contact": "Liên hệ"
+  },
+  "private": {
+    "playlist": "Riêng tư",
+    "profile": "Riêng tư"
+  },
+  "donate": {
+    "header": "Quyên góp",
+    "content": [
+      "muffon là một dự án phi lợi nhuận không có quảng cáo cũng như bất kỳ tính năng hoặc nội dung trả phí nào.",
+      "Tuy nhiên, muffon không thể tồn tại nếu không có kinh phí cần thiết cho việc phát triển và cơ sở hạ tầng.",
+      "Rất nhiều thời gian và công sức đã được bỏ ra để tạo ra dự án này, sẽ thật tuyệt vời nếu thấy khoản đầu tư đó được đền đáp.",
+      "Vì vậy, chúng tôi muốn nhờ sự giúp đỡ của bạn trong việc hỗ trợ muffon.",
+      "<strong>Bạn có muốn quyên góp không?</strong>"
+    ],
+    "actions": {
+      "decline": "Không, cảm ơn",
+      "later": "Có thể sau",
+      "accept": "Được, chắc chắn rồi"
+    }
+  },
+  "lists": {
+    "simple": "Danh sách đơn giản",
+    "table": "Bảng",
+    "extended": "Danh sách chi tiết"
+  },
+  "orders": {
+    "createdDesc": "Mới nhất",
+    "createdAsc": "Cũ nhất",
+    "updatedDesc": "Cập nhật gần đây nhất",
+    "updatedAsc": "Cập nhật lâu nhất",
+    "artistsCountDesc": "Nhiều nghệ sĩ nhất",
+    "artistsCountAsc": "Ít nghệ sĩ nhất",
+    "albumsCountDesc": "Nhiều album nhất",
+    "albumsCountAsc": "Ít album nhất",
+    "tracksCountDesc": "Nhiều bài hát nhất",
+    "tracksCountAsc": "Ít bài hát nhất",
+    "followersCountDesc": "Nhiều người theo dõi nhất",
+    "followersCountAsc": "Ít người theo dõi nhất",
+    "joinedDesc": "Tham gia gần đây nhất",
+    "joinedAsc": "Tham gia lâu nhất",
+    "membersCountDesc": "Nhiều thành viên nhất",
+    "membersCountAsc": "Ít thành viên nhất"
+  },
+  "deletedModel": {
+    "profile": "Hồ sơ đã xóa"
+  },
+  "events": {
+    "created": {
+      "profile": "Hồ sơ được tạo",
+      "bookmarkAlbum": "Album {modelName} được thêm vào đánh dấu",
+      "bookmarkArtist": "Nghệ sĩ {modelName} được thêm vào đánh dấu",
+      "bookmarkTrack": "Bài hát {modelName} được thêm vào đánh dấu",
+      "bookmarkVideo": "Video {modelName} được thêm vào đánh dấu",
+      "bookmarkVideoChannel": "Kênh video {modelName} được thêm vào đánh dấu",
+      "bookmarkVideoPlaylist": "Danh sách phát video {modelName} được thêm vào đánh dấu",
+      "favoriteAlbum": "Album {modelName} được thêm vào yêu thích",
+      "favoriteArtist": "Nghệ sĩ {modelName} được thêm vào yêu thích",
+      "favoriteTrack": "Bài hát {modelName} được thêm vào yêu thích",
+      "favoriteVideo": "Video {modelName} được thêm vào yêu thích",
+      "libraryAlbum": "Album {modelName} được thêm vào thư viện",
+      "libraryArtist": "Nghệ sĩ {modelName} được thêm vào thư viện",
+      "libraryTrack": "Bài hát {modelName} được thêm vào thư viện",
+      "listenedAlbum": "Album {modelName} được thêm vào đã nghe",
+      "listenedArtist": "Nghệ sĩ {modelName} được thêm vào đã nghe",
+      "listenedTrack": "Bài hát {modelName} được thêm vào đã nghe",
+      "watchedVideo": "Video {modelName} được thêm vào đã xem",
+      "playlistTrack": "Bài hát {modelName} được thêm vào danh sách phát {playlistTitle}",
+      "community": "Cộng đồng {modelName} được tạo",
+      "relationship": "Bạn đã theo dõi {modelName}",
+      "post": "Bài viết {modelName} được tạo",
+      "postComment": "Bình luận {modelName} được tạo",
+      "playlist": "Danh sách phát {modelName} được tạo",
+      "conversation": "Bạn đã bắt đầu cuộc trò chuyện với {modelName}",
+      "membership": "Bạn đã tham gia cộng đồng {modelName}"
+    },
+    "updated": {
+      "profile": "Hồ sơ {modelName} được cập nhật",
+      "community": "Cộng đồng {modelName} được cập nhật",
+      "post": "Bài viết {modelName} được cập nhật",
+      "postComment": "Bình luận {modelName} được cập nhật",
+      "playlist": "Danh sách phát {modelName} được cập nhật"
+    },
+    "deleted": {
+      "bookmarkAlbum": "Album {modelName} được xóa khỏi đánh dấu",
+      "bookmarkArtist": "Nghệ sĩ {modelName} được xóa khỏi đánh dấu",
+      "bookmarkTrack": "Bài hát {modelName} được xóa khỏi đánh dấu",
+      "bookmarkVideo": "Video {modelName} được xóa khỏi đánh dấu",
+      "bookmarkVideoChannel": "Kênh video {modelName} được xóa khỏi đánh dấu",
+      "bookmarkVideoPlaylist": "Danh sách phát video {modelName} được xóa khỏi đánh dấu",
+      "favoriteAlbum": "Album {modelName} được xóa khỏi yêu thích",
+      "favoriteArtist": "Nghệ sĩ {modelName} được xóa khỏi yêu thích",
+      "favoriteTrack": "Bài hát {modelName} được xóa khỏi yêu thích",
+      "favoriteVideo": "Video {modelName} được xóa khỏi yêu thích",
+      "libraryAlbum": "Album {modelName} được xóa khỏi thư viện",
+      "libraryArtist": "Nghệ sĩ {modelName} được xóa khỏi thư viện",
+      "libraryTrack": "Bài hát {modelName} được xóa khỏi thư viện",
+      "listenedAlbum": "Album {modelName} được xóa khỏi đã nghe",
+      "listenedArtist": "Nghệ sĩ {modelName} được xóa khỏi đã nghe",
+      "listenedTrack": "Bài hát {modelName} được xóa khỏi đã nghe",
+      "watchedVideo": "Video {modelName} được xóa khỏi đã xem",
+      "playlistTrack": "Bài hát {modelName} được xóa khỏi danh sách phát {playlistTitle}",
+      "community": "Cộng đồng {modelName} được xóa",
+      "recommendationArtist": "Nghệ sĩ {modelName} được xóa khỏi đề xuất",
+      "recommendationTrack": "Bài hát {modelName} được xóa khỏi đề xuất",
+      "relationship": "Bạn đã bỏ theo dõi {modelName}",
+      "post": "Bài viết {modelName} được xóa",
+      "postComment": "Bình luận {modelName} được xóa",
+      "playlist": "Danh sách phát {modelName} được xóa",
+      "membership": "Bạn đã rời khỏi cộng đồng {modelName}"
+    }
+  },
+  "created": {
+    "profile": "Trên muffon từ",
+    "library": "Trong thư viện từ",
+    "community": "Được tạo"
+  },
+  "filter": {
+    "include": {
+      "artists": "Với nghệ sĩ",
+      "tags": "Với thẻ"
+    },
+    "exclude": {
+      "artists": "Không có nghệ sĩ",
+      "tags": "Không có thẻ"
+    }
+  },
+  "keyboardShortcuts": {
+    "header": "Phím tắt",
+    "search": "Hiển thị bảng tìm kiếm",
+    "audioBackward": "Tua lùi âm thanh",
+    "audioForward": "Tua tới âm thanh",
+    "radioNextTrack": "Bài hát radio tiếp theo"
+  },
+  "online": "Trực tuyến",
+  "error": "Lỗi",
+  "more": "Thêm...",
+  "loading": "Đang tải...",
+  "warning": "Cảnh báo"
+}

--- a/src/plugins/i18nCountries.js
+++ b/src/plugins/i18nCountries.js
@@ -14,6 +14,7 @@ import pl from 'i18n-iso-countries/langs/pl.json'
 import ptBr from './i18nCountries/locales/pt_BR.json'
 import ru from 'i18n-iso-countries/langs/ru.json'
 import tr from 'i18n-iso-countries/langs/tr.json'
+import vi from 'i18n-iso-countries/langs/vi.json'
 import zh from 'i18n-iso-countries/langs/zh.json'
 
 // i18n
@@ -32,6 +33,7 @@ const locales = [
   ptBr,
   ru,
   tr,
+  vi,
   zh
 ]
 

--- a/tests/i18n/vi-locale.test.js
+++ b/tests/i18n/vi-locale.test.js
@@ -1,0 +1,365 @@
+/**
+ * Property-Based Tests and Unit Tests for Vietnamese Localization
+ * Feature: vietnamese-localization
+ */
+
+import { describe, test, expect, beforeEach } from 'vitest'
+import * as fc from 'fast-check'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+import { createI18n } from 'vue-i18n'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// Load locale files
+const enLocale = JSON.parse(
+  readFileSync(join(__dirname, '../../src/plugins/i18n/locales/en.json'), 'utf-8')
+)
+const viLocale = JSON.parse(
+  readFileSync(join(__dirname, '../../src/plugins/i18n/locales/vi.json'), 'utf-8')
+)
+const backendViLocale = JSON.parse(
+  readFileSync(join(__dirname, '../../electron/plugins/i18n/locales/vi.json'), 'utf-8')
+)
+
+/**
+ * Helper function to get all nested keys from an object
+ * Returns an array of dot-notation paths (e.g., ['navigation.home', 'navigation.artists'])
+ */
+function getAllKeys(obj, prefix = '') {
+  const keys = []
+  
+  for (const key in obj) {
+    const fullKey = prefix ? `${prefix}.${key}` : key
+    
+    if (typeof obj[key] === 'object' && obj[key] !== null && !Array.isArray(obj[key])) {
+      keys.push(...getAllKeys(obj[key], fullKey))
+    } else {
+      keys.push(fullKey)
+    }
+  }
+  
+  return keys
+}
+
+/**
+ * Helper function to get value from nested object using dot notation
+ */
+function getNestedValue(obj, path) {
+  return path.split('.').reduce((current, key) => current?.[key], obj)
+}
+
+/**
+ * Helper function to get all nested paths from an object including intermediate objects
+ * Returns an array of objects with path and type information
+ */
+function getAllPaths(obj, prefix = '') {
+  const paths = []
+  
+  for (const key in obj) {
+    const fullKey = prefix ? `${prefix}.${key}` : key
+    const value = obj[key]
+    
+    if (value === null) {
+      paths.push({ path: fullKey, type: 'null' })
+    } else if (Array.isArray(value)) {
+      paths.push({ path: fullKey, type: 'array' })
+    } else if (typeof value === 'object') {
+      paths.push({ path: fullKey, type: 'object' })
+      paths.push(...getAllPaths(value, fullKey))
+    } else {
+      paths.push({ path: fullKey, type: typeof value })
+    }
+  }
+  
+  return paths
+}
+
+describe('Vietnamese Localization - Unit Tests', () => {
+  /**
+   * Test that vi.json files are valid JSON
+   * Requirements: 1.1, 3.1, 3.2
+   */
+  test('Frontend vi.json is valid JSON', () => {
+    // If we got here, the file was successfully parsed
+    expect(viLocale).toBeDefined()
+    expect(typeof viLocale).toBe('object')
+    expect(viLocale).not.toBeNull()
+  })
+
+  test('Backend vi.json is valid JSON', () => {
+    // If we got here, the file was successfully parsed
+    expect(backendViLocale).toBeDefined()
+    expect(typeof backendViLocale).toBe('object')
+    expect(backendViLocale).not.toBeNull()
+  })
+
+  /**
+   * Test that frontend i18n loads Vietnamese locale successfully
+   * Requirements: 1.1, 3.1
+   */
+  test('Frontend i18n loads Vietnamese locale successfully', () => {
+    const i18n = createI18n({
+      locale: 'vi',
+      fallbackLocale: 'en',
+      messages: {
+        en: enLocale,
+        vi: viLocale
+      }
+    })
+
+    // Check that Vietnamese locale is available
+    expect(i18n.global.availableLocales).toContain('vi')
+    
+    // Check that messages are loaded
+    expect(i18n.global.messages.vi).toBeDefined()
+    expect(Object.keys(i18n.global.messages.vi).length).toBeGreaterThan(0)
+  })
+
+  /**
+   * Test locale switching to 'vi' returns Vietnamese strings
+   * Requirements: 1.2
+   */
+  test('Locale switching to vi returns Vietnamese strings', () => {
+    const i18n = createI18n({
+      locale: 'en',
+      fallbackLocale: 'en',
+      messages: {
+        en: enLocale,
+        vi: viLocale
+      }
+    })
+
+    // Initially in English
+    expect(i18n.global.t('navigation.home')).toBe('Home page')
+
+    // Switch to Vietnamese
+    i18n.global.locale = 'vi'
+    expect(i18n.global.t('navigation.home')).toBe('Trang chủ')
+    
+    // Test another key
+    expect(i18n.global.t('navigation.artists')).toBe('Nghệ sĩ')
+  })
+
+  /**
+   * Test fallback to English for missing keys
+   * Requirements: 1.3
+   */
+  test('Fallback to English for missing keys', () => {
+    // Create a Vietnamese locale with a missing key
+    const incompleteViLocale = {
+      navigation: {
+        home: 'Trang chủ'
+        // Missing 'artists' key
+      }
+    }
+
+    const i18n = createI18n({
+      locale: 'vi',
+      fallbackLocale: 'en',
+      messages: {
+        en: {
+          navigation: {
+            home: 'Home',
+            artists: 'Artists'
+          }
+        },
+        vi: incompleteViLocale
+      }
+    })
+
+    // Existing key returns Vietnamese
+    expect(i18n.global.t('navigation.home')).toBe('Trang chủ')
+    
+    // Missing key falls back to English
+    expect(i18n.global.t('navigation.artists')).toBe('Artists')
+  })
+
+  /**
+   * Test interpolation works with Vietnamese strings
+   * Requirements: 2.2
+   */
+  test('Interpolation works with Vietnamese strings', () => {
+    // Create test locales with interpolation
+    const testEnLocale = {
+      greeting: 'Hello {name}',
+      count: '{count} items'
+    }
+
+    const testViLocale = {
+      greeting: 'Xin chào {name}',
+      count: '{count} mục'
+    }
+
+    const i18n = createI18n({
+      locale: 'vi',
+      fallbackLocale: 'en',
+      messages: {
+        en: testEnLocale,
+        vi: testViLocale
+      }
+    })
+
+    // Test interpolation with Vietnamese
+    expect(i18n.global.t('greeting', { name: 'Minh' })).toBe('Xin chào Minh')
+    expect(i18n.global.t('count', { count: 5 })).toBe('5 mục')
+  })
+
+  /**
+   * Test that Vietnamese locale contains expected top-level keys
+   * Requirements: 1.1, 4.1
+   */
+  test('Vietnamese locale contains expected structure', () => {
+    // Check for major top-level keys that should exist
+    const expectedKeys = ['navigation', 'errors', 'actions', 'links', 'inputs', 'modals']
+    
+    expectedKeys.forEach(key => {
+      expect(viLocale).toHaveProperty(key)
+      expect(typeof viLocale[key]).toBe('object')
+    })
+  })
+
+  /**
+   * Test that backend Vietnamese locale has expected structure
+   * Requirements: 2.1, 3.2
+   * 
+   * Note: Backend locale has a different, smaller structure than frontend
+   * as it only contains Electron app-specific strings
+   */
+  test('Backend Vietnamese locale has expected structure', () => {
+    // Backend should have the expected keys for Electron app
+    const expectedBackendKeys = ['show', 'hide', 'about', 'quit', 'update']
+    
+    expectedBackendKeys.forEach(key => {
+      expect(backendViLocale).toHaveProperty(key)
+    })
+    
+    // Backend locale should be a valid object
+    expect(typeof backendViLocale).toBe('object')
+    expect(Object.keys(backendViLocale).length).toBeGreaterThan(0)
+  })
+})
+
+describe('Vietnamese Localization - Property Tests', () => {
+  /**
+   * Feature: vietnamese-localization, Property 2: Interpolation variables are preserved
+   * Validates: Requirements 2.2
+   * 
+   * For any translation key containing interpolation variables in en.json,
+   * all interpolation variables should also exist in the Vietnamese translation.
+   */
+  test('Property 2: Interpolation variables are preserved', () => {
+    const allEnglishKeys = getAllKeys(enLocale)
+    
+    // Filter keys that contain interpolation variables
+    const keysWithVariables = allEnglishKeys.filter(key => {
+      const enValue = getNestedValue(enLocale, key)
+      if (typeof enValue !== 'string') return false
+      return /\{[^}]+\}/g.test(enValue)
+    })
+    
+    // Create a property-based test that checks keys with interpolation variables
+    const keyArbitrary = fc.constantFrom(...keysWithVariables)
+    
+    fc.assert(
+      fc.property(keyArbitrary, (key) => {
+        const enValue = getNestedValue(enLocale, key)
+        const viValue = getNestedValue(viLocale, key)
+        
+        // Extract interpolation variables from English string
+        const enVariables = enValue.match(/\{[^}]+\}/g) || []
+        
+        // Extract interpolation variables from Vietnamese string
+        const viVariables = viValue.match(/\{[^}]+\}/g) || []
+        
+        // Sort both arrays for comparison
+        const sortedEnVariables = [...enVariables].sort()
+        const sortedViVariables = [...viVariables].sort()
+        
+        // The Vietnamese translation must contain the same variables
+        expect(sortedViVariables).toEqual(sortedEnVariables)
+        
+        return true
+      }),
+      { numRuns: 100 } // Run minimum 100 iterations as specified
+    )
+  })
+
+  /**
+   * Feature: vietnamese-localization, Property 3: JSON structure matches English locale
+   * Validates: Requirements 2.4
+   * 
+   * For any nested key path in en.json, the same key path should exist in vi.json
+   * with the same structure (object vs string vs array).
+   */
+  test('Property 3: JSON structure matches English locale', () => {
+    const allEnglishPaths = getAllPaths(enLocale)
+    
+    // Create a property-based test that checks all nested paths
+    const pathArbitrary = fc.constantFrom(...allEnglishPaths)
+    
+    fc.assert(
+      fc.property(pathArbitrary, (pathInfo) => {
+        const { path, type } = pathInfo
+        const viValue = getNestedValue(viLocale, path)
+        
+        // The path must exist in Vietnamese locale
+        expect(viValue).toBeDefined()
+        
+        // Determine the type of the Vietnamese value
+        let viType
+        if (viValue === null) {
+          viType = 'null'
+        } else if (Array.isArray(viValue)) {
+          viType = 'array'
+        } else if (typeof viValue === 'object') {
+          viType = 'object'
+        } else {
+          viType = typeof viValue
+        }
+        
+        // The type must match the English locale
+        expect(viType).toBe(type)
+        
+        return true
+      }),
+      { numRuns: 100 } // Run minimum 100 iterations as specified
+    )
+  })
+
+  /**
+   * Feature: vietnamese-localization, Property 4: All English keys have Vietnamese translations
+   * Validates: Requirements 4.1
+   * 
+   * For any translation key in en.json, there should be a corresponding key in vi.json.
+   */
+  test('Property 4: All English keys have Vietnamese translations', () => {
+    const allEnglishKeys = getAllKeys(enLocale)
+    
+    // Create a property-based test that checks all English keys
+    const keyArbitrary = fc.constantFrom(...allEnglishKeys)
+    
+    fc.assert(
+      fc.property(keyArbitrary, (key) => {
+        const viValue = getNestedValue(viLocale, key)
+        
+        // The key must exist in Vietnamese locale
+        expect(viValue).toBeDefined()
+        
+        // The value should not be null or undefined
+        expect(viValue).not.toBeNull()
+        expect(viValue).not.toBeUndefined()
+        
+        // The value should be a non-empty string
+        if (typeof viValue === 'string') {
+          expect(viValue.trim()).not.toBe('')
+        }
+        
+        return true
+      }),
+      { numRuns: 100 } // Run minimum 100 iterations as specified
+    )
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.js']
+  }
+})


### PR DESCRIPTION
- Add Vietnamese translation files for frontend and backend
- Register Vietnamese locale in i18n systems
- Add Vietnamese to language selection list
- Add dayjs and i18n-countries Vietnamese locale support
- Add property-based tests and unit tests for Vietnamese locale
- All tests passing (11/11)

Implements complete Vietnamese language support with proper diacritics and UTF-8 encoding.