### PR TITLE
fix (readme): restore star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,19 +119,19 @@ Discography:
 
 ## Star History
 
-<a href="https://star-history.com/#staniel359/muffon&Date">
+<a href="https://star-history.dera.page/#staniel359/muffon&type=Date">
   <picture>
     <source
       media="(prefers-color-scheme: dark)"
-      srcset="https://api.star-history.com/svg?repos=staniel359/muffon&type=Date&theme=dark"
+      srcset="https://star-history.dera.page/svg?repos=staniel359/muffon&type=Date&theme=dark"
     />
     <source
       media="(prefers-color-scheme: light)"
-      srcset="https://api.star-history.com/svg?repos=staniel359/muffon&type=Date"
+      srcset="https://star-history.dera.page/svg?repos=staniel359/muffon&type=Date"
     />
     <img
       alt="Star History Chart"
-      src="https://api.star-history.com/svg?repos=staniel359/muffon&type=Date"
+      src="https://star-history.dera.page/svg?repos=staniel359/muffon&type=Date"
     />
   </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is broken because it relies on the GitHub stargazer API, which has become restricted. This change points the chart to an alternative data source that requires no API token, so the chart displays correctly again.